### PR TITLE
Fixed issues caused by LuckPerms changes

### DIFF
--- a/minestom/build.gradle
+++ b/minestom/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    var minestom = "net.minestom:minestom-snapshots:2065f63f82"
+    var minestom = "net.minestom:minestom-snapshots:0366b58bfe"
 
     api(project(":common")) {
         // exclude default config providers as they are inaccessible from the minestom module anyway

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/context/MinestomContextManager.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/context/MinestomContextManager.java
@@ -1,37 +1,16 @@
 package me.lucko.luckperms.minestom.context;
 
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import me.lucko.luckperms.common.cache.LoadingMap;
-import me.lucko.luckperms.common.config.ConfigKeys;
-import me.lucko.luckperms.common.context.manager.ContextManager;
-import me.lucko.luckperms.common.context.manager.QueryOptionsCache;
+
+import me.lucko.luckperms.common.context.manager.DetachedContextManager;
 import me.lucko.luckperms.common.context.manager.QueryOptionsSupplier;
 import me.lucko.luckperms.common.plugin.LuckPermsPlugin;
-import me.lucko.luckperms.common.util.CaffeineFactory;
-import net.luckperms.api.context.ImmutableContextSet;
-import net.luckperms.api.query.QueryOptions;
 import net.minestom.server.entity.Player;
 
-public final class MinestomContextManager extends ContextManager<Player, Player> {
-
-    private final LoadingMap<Player, QueryOptionsCache<Player>> onlineSubjectCaches = LoadingMap.of(key -> new QueryOptionsCache<>(key, this));
-
-    private final LoadingCache<Player, QueryOptionsCache<Player>> offlineSubjectCaches = CaffeineFactory.newBuilder()
-            .expireAfterAccess(1, TimeUnit.MINUTES)
-            .build(key -> {
-                QueryOptionsCache<Player> cache = this.onlineSubjectCaches.getIfPresent(key);
-                return Objects.requireNonNullElseGet(cache, () -> new QueryOptionsCache<>(key, this));
-            });
+public final class MinestomContextManager extends DetachedContextManager<Player, Player> {
 
     public MinestomContextManager(LuckPermsPlugin plugin) {
         super(plugin, Player.class, Player.class);
-    }
-
-    public void onPlayerQuit(Player player) {
-        this.onlineSubjectCaches.remove(player);
     }
 
     @Override
@@ -40,30 +19,8 @@ public final class MinestomContextManager extends ContextManager<Player, Player>
     }
 
     @Override
-    public QueryOptionsSupplier getCacheFor(Player subject) {
-        if (subject == null) throw new NullPointerException("subject");
-
-        if (subject.isOnline()) return this.onlineSubjectCaches.get(subject);
-        return this.offlineSubjectCaches.get(subject);
-    }
-
-    @Override
-    public QueryOptions formQueryOptions(Player subject, ImmutableContextSet contextSet) {
-        return this.plugin.getConfiguration().get(ConfigKeys.GLOBAL_QUERY_OPTIONS).toBuilder()
-                .context(contextSet).build();
-    }
-
-    @Override
-    protected void invalidateCache(Player subject) {
-        QueryOptionsCache<Player> cache = this.onlineSubjectCaches.getIfPresent(subject);
-        if (cache != null) {
-            cache.invalidate();
-        }
-
-        cache = this.offlineSubjectCaches.getIfPresent(subject);
-        if (cache != null) {
-            cache.invalidate();
-        }
+    public QueryOptionsSupplier getQueryOptionsSupplier(Player subject) {
+        return null;
     }
 
 }

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/listeners/MinestomConnectionListener.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/listeners/MinestomConnectionListener.java
@@ -9,7 +9,6 @@ import me.lucko.luckperms.common.model.User;
 import me.lucko.luckperms.common.plugin.util.AbstractConnectionListener;
 import me.lucko.luckperms.minestom.LPMinestomPlugin;
 import net.kyori.adventure.text.Component;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/listeners/MinestomConnectionListener.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/listeners/MinestomConnectionListener.java
@@ -95,8 +95,6 @@ public final class MinestomConnectionListener extends AbstractConnectionListener
     private void onPlayerDisconnect(PlayerDisconnectEvent event) {
         final Player player = event.getPlayer();
         handleDisconnect(player.getUuid());
-
-        MinecraftServer.getSchedulerManager().scheduleNextTick(() -> this.plugin.getContextManager().onPlayerQuit(player));
     }
 
 }


### PR DESCRIPTION
Hey, the following change from the LuckPerms Repository (https://github.com/LuckPerms/LuckPerms/commit/6b7283ac836324e441956056307e34c82d51b015) caused the following issue when using LuckPerms on Minestom:
```
Exception in thread "main" java.lang.IllegalAccessError: failed to access class me.lucko.luckperms.common.context.manager.QueryOptionsCache from class me.lucko.luckperms.minestom.context.MinestomContextManager (me.lucko.luckperms.common.context.manager.QueryOptionsCache and me.lucko.luckperms.minestom.context.MinestomContextManager are in unnamed module of loader 'app')
        at me.lucko.luckperms.minestom.context.MinestomContextManager.<init>(MinestomContextManager.java:20)
        at me.lucko.luckperms.minestom.LPMinestomPlugin.setupContextManager(LPMinestomPlugin.java:128)
        at me.lucko.luckperms.common.plugin.AbstractLuckPermsPlugin.enable(AbstractLuckPermsPlugin.java:224)
        at me.lucko.luckperms.minestom.LPMinestomBootstrap.onEnable(LPMinestomBootstrap.java:68)
        at me.lucko.luckperms.minestom.LuckPermsMinestom$BuilderImpl.enable(LuckPermsMinestom.java:266)
...
```

In this PR, I tried to fix the issues, and everything seems to work again. (Additionally, I updated the Minestom commit to latest.)
If there are still any issues, please let me know.