### PR TITLE
add external permission handler fallback for command permission checks

### DIFF
--- a/minestom/src/main/java/me/lucko/luckperms/minestom/LPMinestomBootstrap.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/LPMinestomBootstrap.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import me.lucko.luckperms.common.config.generic.adapter.ConfigurationAdapter;
 import me.lucko.luckperms.common.plugin.bootstrap.LuckPermsBootstrap;
@@ -17,7 +18,9 @@ import me.lucko.luckperms.common.plugin.scheduler.SchedulerAdapter;
 import me.lucko.luckperms.minestom.context.ContextProvider;
 import me.lucko.luckperms.minestom.dependencies.NoopClassPathAppender;
 import net.luckperms.api.platform.Platform;
+import net.luckperms.api.util.Tristate;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.command.CommandSender;
 import net.minestom.server.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,12 +44,13 @@ public final class LPMinestomBootstrap implements LuckPermsBootstrap {
             @NotNull Set<ContextProvider> contextProviders,
             @NotNull Function<LPMinestomPlugin, ConfigurationAdapter> configurationAdapter,
             @NotNull Set<String> permissionSuggestions,
-            @Nullable CommandRegistry commandRegistry
-    ) {
+            @Nullable CommandRegistry commandRegistry,
+            @NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler
+            ) {
         this.logger = new Slf4jPluginLogger(logger);
         this.dataDirectory = dataDirectory;
         this.schedulerAdapter = new MinestomSchedulerAdapter(this);
-        this.plugin = new LPMinestomPlugin(this, contextProviders, configurationAdapter, permissionSuggestions, commandRegistry);
+        this.plugin = new LPMinestomPlugin(this, contextProviders, configurationAdapter, permissionSuggestions, commandRegistry, externalPermissionHandler);
     }
 
     public void onEnable() {

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/LPMinestomPlugin.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/LPMinestomPlugin.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import me.lucko.luckperms.common.api.LuckPermsApiProvider;
@@ -37,7 +38,9 @@ import me.lucko.luckperms.minestom.listeners.MinestomConnectionListener;
 import me.lucko.luckperms.minestom.messaging.MinestomMessagingFactory;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.query.QueryOptions;
+import net.luckperms.api.util.Tristate;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.command.CommandSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
@@ -53,6 +56,7 @@ public final class LPMinestomPlugin extends AbstractLuckPermsPlugin {
     private final @NotNull Set<String> permissionSuggestions;
     private final @NotNull ConfigurationAdapter configurationAdapter;
     private final @Nullable CommandRegistry commandRegistry;
+    private final @NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler;
 
     private MinestomSenderFactory senderFactory;
     private MinestomContextManager contextManager;
@@ -67,18 +71,20 @@ public final class LPMinestomPlugin extends AbstractLuckPermsPlugin {
             @NotNull Set<ContextProvider> contextProviders,
             @NotNull Function<LPMinestomPlugin, ConfigurationAdapter> configurationAdapter,
             @NotNull Set<String> permissionSuggestions,
-            @Nullable CommandRegistry commandRegistry
-    ) {
+            @Nullable CommandRegistry commandRegistry,
+            @NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler
+            ) {
         this.bootstrap = bootstrap;
         this.contextProviders = contextProviders;
         this.permissionSuggestions = permissionSuggestions;
         this.configurationAdapter = configurationAdapter.apply(this);
         this.commandRegistry = commandRegistry;
+        this.externalPermissionHandler = externalPermissionHandler;
     }
 
     @Override
     protected void setupSenderFactory() {
-        this.senderFactory = new MinestomSenderFactory(this);
+        this.senderFactory = new MinestomSenderFactory(this, this.externalPermissionHandler);
     }
 
     @Override

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/LuckPermsMinestom.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/LuckPermsMinestom.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import me.lucko.luckperms.common.config.generic.adapter.ConfigurationAdapter;
@@ -11,6 +12,8 @@ import me.lucko.luckperms.common.config.generic.adapter.EnvironmentVariableConfi
 import me.lucko.luckperms.minestom.context.ContextProvider;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.util.Tristate;
+import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -158,6 +161,16 @@ public final class LuckPermsMinestom {
         @Contract("_ -> this")
         @NotNull Builder logger(@NotNull Logger logger);
 
+        /**
+         * Sets an external permission handler used for permission checking in
+         * LuckPerms commands (as a fallback when no matching LuckPerms permission is set)
+         *
+         * @param externalPermissionHandler the permission handler
+         * @return the builder instance
+         */
+        @Contract("_ -> this")
+        @NotNull Builder externalPermissionHandler(@NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler);
+
 
         /**
          * Enables LuckPerms
@@ -177,6 +190,7 @@ public final class LuckPermsMinestom {
         private @Nullable CommandRegistry commandRegistry;
         private @NotNull Function<LPMinestomPlugin, ConfigurationAdapter> configurationAdapter = EnvironmentVariableConfigAdapter::new;
         private @NotNull Logger logger = LoggerFactory.getLogger(LuckPermsMinestom.class);
+        private @NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler = (sender, node) -> Tristate.UNDEFINED;
 
         private BuilderImpl(@NotNull Path dataDirectory) {
             this.dataDirectory = dataDirectory;
@@ -235,6 +249,12 @@ public final class LuckPermsMinestom {
         }
 
         @Override
+        public @NotNull Builder externalPermissionHandler(@NotNull BiFunction<CommandSender, String, Tristate> externalPermissionHandler) {
+            this.externalPermissionHandler = externalPermissionHandler;
+            return this;
+        }
+
+        @Override
         public @NotNull LuckPerms enable() {
             bootstrap = new LPMinestomBootstrap(
                     this.logger,
@@ -242,7 +262,8 @@ public final class LuckPermsMinestom {
                     this.contextProviders,
                     this.configurationAdapter,
                     this.permissionSuggestions,
-                    this.commandRegistry
+                    this.commandRegistry,
+                    this.externalPermissionHandler
             );
             bootstrap.onEnable();
             return LuckPermsProvider.get();

--- a/minestom/src/main/java/me/lucko/luckperms/minestom/MinestomSenderFactory.java
+++ b/minestom/src/main/java/me/lucko/luckperms/minestom/MinestomSenderFactory.java
@@ -1,6 +1,8 @@
 package me.lucko.luckperms.minestom;
 
 import java.util.UUID;
+import java.util.function.BiFunction;
+
 import me.lucko.luckperms.common.locale.TranslationManager;
 import me.lucko.luckperms.common.sender.Sender;
 import me.lucko.luckperms.common.sender.SenderFactory;
@@ -14,10 +16,12 @@ import net.minestom.server.entity.Player;
 public final class MinestomSenderFactory extends SenderFactory<LPMinestomPlugin, CommandSender> {
 
     private final LPMinestomPlugin plugin;
+    private final BiFunction<CommandSender, String, Tristate> externalPermissionHandler;
 
-    public MinestomSenderFactory(LPMinestomPlugin plugin) {
+    public MinestomSenderFactory(LPMinestomPlugin plugin, BiFunction<CommandSender, String, Tristate> externalPermissionHandler) {
         super(plugin);
         this.plugin = plugin;
+        this.externalPermissionHandler = externalPermissionHandler;
     }
 
     @Override
@@ -37,15 +41,21 @@ public final class MinestomSenderFactory extends SenderFactory<LPMinestomPlugin,
 
     @Override
     protected Tristate getPermissionValue(CommandSender sender, String node) {
-        return sender instanceof Player player ? this.plugin.getApiProvider().getPlayerAdapter(Player.class).getPermissionData(player)
-                .checkPermission(node) : Tristate.TRUE;
+        if(sender instanceof Player player) {
+            Tristate result = this.plugin.getApiProvider()
+                    .getPlayerAdapter(Player.class)
+                    .getPermissionData(player)
+                    .checkPermission(node);
+            if(result != Tristate.UNDEFINED) {
+                return result;
+            }
+        }
+        return this.externalPermissionHandler.apply(sender, node);
     }
 
     @Override
     protected boolean hasPermission(CommandSender sender, String node) {
-        return !(sender instanceof Player player) || this.plugin.getApiProvider().getPlayerAdapter(Player.class).getPermissionData(player)
-                .checkPermission(node)
-                .asBoolean();
+        return this.getPermissionValue(sender, node).asBoolean();
     }
 
     @Override

--- a/minestom/src/test/java/me/lucko/luckperms/minestom/MinestomServer.java
+++ b/minestom/src/test/java/me/lucko/luckperms/minestom/MinestomServer.java
@@ -10,6 +10,7 @@ import net.luckperms.api.LuckPerms;
 import net.luckperms.api.context.DefaultContextKeys;
 import net.luckperms.api.context.ImmutableContextSet;
 import net.luckperms.api.node.Node;
+import net.luckperms.api.util.Tristate;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.builder.Command;
@@ -41,7 +42,9 @@ public final class MinestomServer {
                 .configurationAdapter(plugin -> new MultiConfigurationAdapter(plugin,
                         new EnvironmentVariableConfigAdapter(plugin),
                         new HoconConfigurationAdapter(plugin)
-                )).permissionSuggestions("test.permission", "test.other")
+                ))
+                .permissionSuggestions("test.permission", "test.other")
+                .externalPermissionHandler((sender, permission) -> Tristate.of(permission.equals("luckperms.editor") || permission.equals("luckperms.applyedits")))
                 .enable();
 
         // set custom player provider (optional)


### PR DESCRIPTION
Adds a new optional builder option `externelPermissionHandler` that is used in `MinestomSenderFactory#getPermissionValue` as a fallback when the LuckPerms permission value is `Tristate.UNDEFINED` or the command sender is not a player.

A possible use case is to give some players permissions to the LuckPerms commands (in debug environments), which is normally more difficult as Minestom does not have a console that could be used to set the initial permissions.

Example (allows everyone to edit permissions with the editor):
```java
LuckPerms luckPerms = LuckPermsMinestom.builder(directory)
        .commandRegistry(CommandRegistry.minestom())
        .externalPermissionHandler((sender, permission) -> Tristate.of(permission.equals("luckperms.editor") || permission.equals("luckperms.applyedits")))
        .enable();
```
Example (Gives access to LuckPerms commands to an admin user defined in an environment variable)
```java
LuckPerms luckPerms = LuckPermsMinestom.builder(directory)
        .commandRegistry(CommandRegistry.minestom())
        .externalPermissionHandler((sender, permission) -> sender instanceof Player player 
                && player.getUsername().equalsIgnoreCase(System.getenv("LUCKPERMS_ADMIN")) ?
                Tristate.TRUE : Tristate.UNDEFINED)

        .enable();
```